### PR TITLE
parallel routing

### DIFF
--- a/src/app/about/@category/default.tsx
+++ b/src/app/about/@category/default.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Default() {
+  return <div>loading</div>;
+}

--- a/src/app/about/@category/page.tsx
+++ b/src/app/about/@category/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+import React from "react";
+import style from "./style.module.scss";
+
+export default function Category() {
+  return (
+    <div className={style.box}>
+      카테고리 <Link href="/about/modal">모달</Link>
+    </div>
+  );
+}

--- a/src/app/about/@category/style.module.scss
+++ b/src/app/about/@category/style.module.scss
@@ -1,0 +1,5 @@
+.box {
+  background-color: aqua;
+  width: 100%;
+  height: 300px;
+}

--- a/src/app/about/@exception/default.tsx
+++ b/src/app/about/@exception/default.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Default() {
+  return <div>s</div>;
+}

--- a/src/app/about/@exception/modal/page.tsx
+++ b/src/app/about/@exception/modal/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useParams, usePathname, useRouter } from "next/navigation";
+import React from "react";
+import style from "./style.module.scss";
+
+export default function Modal() {
+  const router = useRouter();
+  const path = usePathname();
+  const params = useParams();
+  console.log(params, "<<?");
+
+  return (
+    <div className={style.background}>
+      <div className={style.back} onClick={() => router.back()} />
+      <div className={style.modal}>{path}</div>
+    </div>
+  );
+}

--- a/src/app/about/@exception/modal/style.module.scss
+++ b/src/app/about/@exception/modal/style.module.scss
@@ -1,0 +1,27 @@
+.background {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.back {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: black;
+  opacity: 0.3;
+}
+
+.modal {
+  width: 300px;
+  height: 300px;
+  background-color: white;
+  z-index: 10;
+}

--- a/src/app/about/@exception/page.tsx
+++ b/src/app/about/@exception/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Modal() {
+  return null;
+}

--- a/src/app/about/@item/default.tsx
+++ b/src/app/about/@item/default.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import React, { useEffect } from "react";
+
+export default function Default() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/about");
+  }, []);
+
+  return <div>loading</div>;
+}

--- a/src/app/about/@item/page.tsx
+++ b/src/app/about/@item/page.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import style from "./style.module.scss";
+
+export default function Item() {
+  return <div className={style.box}>아이템</div>;
+}

--- a/src/app/about/@item/style.module.scss
+++ b/src/app/about/@item/style.module.scss
@@ -1,0 +1,5 @@
+.box {
+  background-color: aliceblue;
+  width: 100%;
+  height: 300px;
+}

--- a/src/app/about/default.tsx
+++ b/src/app/about/default.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Default() {
+  return <div>loading</div>;
+}

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,11 +1,29 @@
+"use client";
+
+import { useSelectedLayoutSegment } from "next/navigation";
 import React from "react";
 import style from "./style.module.scss";
 
-export default function layout({ children }: { children: React.ReactNode }) {
+export default function Layout({
+  category,
+  item,
+  exception,
+}: {
+  category: React.ReactNode;
+  item: React.ReactNode;
+  exception: React.ReactNode;
+}) {
+  console.log("hi");
+  const segments = useSelectedLayoutSegment();
+  console.log(segments, "<<");
   return (
     <>
-      <header className={style.header}>About 헤더</header>
-      {children}
+      <div className={style.header}>About 헤더 {segments}</div>
+      <section className={style.section}>
+        {category}
+        {item}
+        {exception}
+      </section>
     </>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,8 +1,13 @@
+import Link from "next/link";
 import React from "react";
 import style from "./style.module.scss";
 
 const About = () => {
-  return <main className={style.main}>about 페이지</main>;
+  return (
+    <main className={style.main}>
+      about 페이지<Link href="/about/modal">modal</Link>
+    </main>
+  );
 };
 
 export default About;

--- a/src/app/about/style.module.scss
+++ b/src/app/about/style.module.scss
@@ -7,5 +7,10 @@
 
 .main {
   width: 100%;
-  height: 100vh;
+}
+
+.section {
+  width: 100%;
+  display: flex;
+  height: 300vh;
 }


### PR DESCRIPTION
병렬 라우팅, 폴더이름 앞에 @을 붙이게 되면

해당 폴더이름을 layout에서 받아와 레이아웃단에서 페이지 처리를 할 수 있다.

예를 들어 about 폴더 하위에 @a , @b 두 폴더를 가지고 각각의 폴더에 page 파일이 존재한다면,

about 폴더에 layout 파일에서 a,b 를 props로 받아올 수 있고, children 까지 총 3개의 props를 가질 수 있고,

/about 에 접속하면 a와 b 페이지를 확인 할 수 있다.

페이지가 존재하지 않을 경우에는 폴더 내 default 파일을 먼저 불러오게 된다.

예를들어 @a 폴더 내부에 aa라는 폴더와 페이지 파일이 존재한다면,

/about/aa 에 접근할 수 있다(여기서 url 직접입력 및 해당페이지에서의 새로고침을 할 때에는 404 또는 default 페이지 -> b 폴더내부에는 

aa 경로에 해당하는 폴더 및 파일이 존재하지 않기 때문에, Link 및 라우팅으로 이동할 시에는 모든 화면이 렌더링 된다.)

따라서 @로 이름지어진 폴더 내부에 modal 을 만들어두면 링크 및 라우팅으로 모달을 제어할 수 있다(모달을 제거할땐 뒤로가기를 해주면 되고,

새로고침을 눌렀을때는 default 페이지에서 리다이렉팅을 시켜주면 된다.)
