### PR TITLE
Magnify image scanner

### DIFF
--- a/src/app/basicRouting/[id]/page.tsx
+++ b/src/app/basicRouting/[id]/page.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export default function page({ params: { id } }: { params: { id: string } }) {
-  return <div>post : {id} 상세페이지</div>;
-}

--- a/src/app/basicRouting/image/page.tsx
+++ b/src/app/basicRouting/image/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import S from "./styles.module.scss";
+import Image from "next/image";
+
+export default function ImagePage() {
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  const imgSize = useMemo(() => {
+    return { width: 400, height: 600 };
+  }, []);
+
+  const moveHandler = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    event.isPropagationStopped();
+
+    const divOffset = {
+      top: event.currentTarget.offsetTop,
+      left: event.currentTarget.offsetLeft,
+    };
+    const minTop = imgSize.height / 4;
+    const maxTop = imgSize.height - imgSize.height / 4;
+    const minLeft = imgSize.width / 4;
+    const maxLeft = imgSize.width - imgSize.width / 4;
+
+    let posTop, posLeft;
+
+    if (event.pageY < divOffset.top + minTop) {
+      posTop = divOffset.top + minTop;
+    } else if (divOffset.top + maxTop < event.pageY) {
+      posTop = divOffset.top + maxTop;
+    } else {
+      posTop = event.pageY;
+    }
+
+    if (event.pageX < divOffset.left + minLeft) {
+      posLeft = divOffset.left + minLeft;
+    } else if (divOffset.left + maxLeft < event.pageX) {
+      posLeft = divOffset.left + maxLeft;
+    } else {
+      posLeft = event.pageX;
+    }
+
+    posTop &&
+      posLeft &&
+      setPos({ top: posTop - divOffset.top, left: posLeft - divOffset.left });
+  };
+
+  const leaveHandler = () => {
+    setPos(null);
+  };
+
+  return (
+    <main className={S.mainContent}>
+      <div
+        className={S.imgWrapper}
+        onMouseLeave={leaveHandler}
+        onMouseMove={event => moveHandler(event)}
+      >
+        <Image
+          src={`${process.env.NEXT_PUBLIC_MY_S3_URL}/%40timetable.jpg`}
+          width={imgSize.width}
+          height={imgSize.height}
+          alt="image"
+          priority
+        />
+        {pos && (
+          <div
+            className={S.scanDiv}
+            style={{
+              width: imgSize.width / 2,
+              height: imgSize.height / 2,
+              top: pos.top,
+              left: pos.left,
+            }}
+          />
+        )}
+        {pos && (
+          <div
+            className={S.thumbNail}
+            style={{
+              width: imgSize.width,
+              height: imgSize.height,
+              backgroundImage: `url(${process.env.NEXT_PUBLIC_MY_S3_URL}/%40timetable.jpg)`,
+              backgroundPosition: `${-pos.left * 2 + imgSize.width / 2}px ${
+                -pos.top * 2 + imgSize.height / 2
+              }px`,
+            }}
+          />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/basicRouting/image/styles.module.scss
+++ b/src/app/basicRouting/image/styles.module.scss
@@ -1,0 +1,30 @@
+.mainContent {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 200vh;
+  gap: 10px;
+}
+
+.imgWrapper {
+  position: relative;
+  width: fit-content;
+  align-self: flex-start;
+}
+
+.scanDiv {
+  position: absolute;
+  background-color: grey;
+  opacity: 0.2;
+  border: 2px solid black;
+  transform: translate(-50%, -50%);
+}
+
+.thumbNail {
+  position: absolute;
+  top: 0;
+  right: -100%;
+  background-color: green;
+  background-repeat: "no-repeat";
+  background-size: 200% 200%;
+}

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,0 +1,21 @@
+interface UserData {
+  name: string;
+  age: string;
+}
+
+interface DetailUserData extends UserData {
+  profile: string;
+}
+
+interface TestProps {
+  a: string;
+  b: UserData | DetailUserData;
+}
+
+export const test = (props: TestProps) => {
+  const { a, b } = props;
+  const atomUserData = b as UserData;
+  const eventDetailUserData = b as DetailUserData;
+
+  return atomUserData || eventDetailUserData;
+};


### PR DESCRIPTION
이미지 element에 마우스를 올렸을때 

마우스 커서 기준 일정영역의 이미지를 확대하여 좌측에 나타나게 하도록 UI 를 구현,

이미지 element 의 top, left offset값을 알고 있어야 하며 width, height 값 또한 주어져야 한다,

배율에 따라 계산식의 값들이 달라지지만, 일단은 2배율로 하였습니다.

해당 영역의 확대된 이미지는 backgroundImg 로 처리,

img의 크기를 width, height를 각각 200%로 세팅하여 처리,

추후 배율에 따른 계산식의 수정이 필요,